### PR TITLE
observableFrom eagerly consumes to avoid lazy CP gotcha

### DIFF
--- a/addon/helpers/observable-from.js
+++ b/addon/helpers/observable-from.js
@@ -35,6 +35,10 @@ export default function observableFrom(propName) {
 
       this.addObserver(propName, fn);
 
+      // this eager consumption is necessary due to lazy CP optimization preventing
+      // observers from properly attaching unless the property is eagerly consumed
+      this.get(propName);
+
       return function(){
         this.removeObserver(propName, fn);
       }.bind(this);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
-    "ember-cli": "0.1.9",
+    "ember-cli": "0.2.0",
     "ember-cli-6to5": "0.2.1",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.7",

--- a/tests/unit/helpers/observable-from-test.js
+++ b/tests/unit/helpers/observable-from-test.js
@@ -3,14 +3,16 @@ import { observableFrom } from 'ember-cli-rx/helpers';
 
 module('helpers/observable-from');
 
-test('it should observe property changes and emit them via an observable', function() {
+function testObservableFromPropertyChanges(useComputedProperty) {
 	stop();
 	var expectedResults = ['Ben', 'Jeff', 'Ranjit'];
 
 	var FooClass = Ember.Object.extend({
 		name: null,
-
-		names: observableFrom('name'),
+    nameAlias: function() {
+      return this.get('name');
+    }.property('name'),
+		names: observableFrom(useComputedProperty ? 'nameAlias' : 'name'),
 	});
 
 	var foo = FooClass.create();
@@ -26,6 +28,14 @@ test('it should observe property changes and emit them via an observable', funct
 	foo.set('name', 'Ben');
 	foo.set('name', 'Jeff');
 	foo.set('name', 'Ranjit');
+}
+
+test('it should observe property changes and emit them via an observable (normal properties)', function() {
+  testObservableFromPropertyChanges(false);
+});
+
+test('it should observe property changes and emit them via an observable (computed properties)', function() {
+  testObservableFromPropertyChanges(true);
 });
 
 test('it should support array.[] observation', function() {
@@ -52,3 +62,4 @@ test('it should support array.[] observation', function() {
 	foo.get('stuff').pushObject('foo');
 	foo.get('stuff').pushObject('bar');
 });
+


### PR DESCRIPTION
If you're using observableFrom('someCp'), it's
likely the Ember observer won't correctly attach
due to the lazy CP optimization in Ember that requires
eager consumption of a computed property if you want
observers to properly attach.

This commit makes observableFrom eagerly consumed
the observed property.

It also bumps ember-cli because I was running into
rim-raf errors that are fixed in 0.2.0
